### PR TITLE
Tweaks .env example and migration scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-DATABASE_URL=postgres://hucache:@localhost:5432/hucache
+export DATABASE_URL=postgres://hucache:@localhost:5432/hucache

--- a/build.fsx
+++ b/build.fsx
@@ -69,7 +69,7 @@ Target "Migrations" (fun _ ->
     |> Seq.iter(fun (filename) ->
         ExecProcess (fun info ->
             info.FileName <- "psql"
-            info.Arguments <- sprintf "-U postgres -f %s" filename
+            info.Arguments <- sprintf "-U postgres -f %s -d hucache" filename
             info.WorkingDirectory <- "./migrations/up") (System.TimeSpan.FromMinutes 5.0) |> ignore
     )
 )


### PR DESCRIPTION
- `.env.example` now suggests prefixing env vars with `export` (otherwise `source` doesn't make its way into the Suave service)
- Migrations build script now runs specifically on the `hucache` db
